### PR TITLE
Add a nonsense unit of measurement for specific gravity

### DIFF
--- a/custom_components/tilt/sensor.py
+++ b/custom_components/tilt/sensor.py
@@ -158,5 +158,9 @@ class SpecificGravitySensor(homeassistant.helpers.entity.Entity):
         return self._tilt.specific_gravity
 
     @property
+    def unit_of_measurement(self):
+        return "SG"
+
+    @property
     def available(self):
         return self._tilt.specific_gravity is not None


### PR DESCRIPTION
Looks like sensor charts on the UI only render as a line graph if you provide a unit of measurement